### PR TITLE
feat: support compiled dart function in node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ doc/api/
 .env*
 *.dart.js
 *.info.json      # Produced by the --dump-info flag.
+src/greeting.js

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ app.listen(port, () => {
 ### notes
 see issue
 - https://github.com/dart-lang/webdev/issues/2432
+
+### Example
+
+Simply run `npm start` and you can then access http://localhost:3000

--- a/greeting.dart
+++ b/greeting.dart
@@ -1,0 +1,8 @@
+import 'package:js/js.dart';
+
+@JS('greeting')
+String greeting() => 'Hello from Dart';
+
+void main() {
+  allowInterop(greeting);
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "\"how to\" import a dart function in node.js",
   "main": "index.js",
   "scripts": {
+    "build:dart": "dartscript --func greeting --out src/greeting.js greeting.dart",
+    "prestart": "npm run build:dart",
     "start": "ts-node-dev src/index.ts"
   },
   "keywords": [],
@@ -15,6 +17,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.12",
+    "dartscript": "^1.0.0-alpha.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
+  js: ^0.7.1
 
 dev_dependencies:
   lints: ^3.0.0

--- a/src/greeting.js
+++ b/src/greeting.js
@@ -1,3 +1,0 @@
-export function greeting() {
-    return "Hello from JS"
-}


### PR DESCRIPTION
Adds an example of how to do this using [`dartscript`](https://github.com/morganney/dartscript). See the npm script `build:dart`.